### PR TITLE
Fix delete record parameter binding

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,7 +90,9 @@ class Main(tk.Frame):
     #Удаление информации о пользователе
     def delete_record(self):
         for select_item in self.tree.selection():
-            self.db.cur.execute('''DELETE FROM db WHERE id=?''', self.tree.set(select_item, '#1'))
+            # sqlite3.execute expects a sequence of parameters; pass a one-item tuple
+            record_id = self.tree.set(select_item, '#1')
+            self.db.cur.execute('''DELETE FROM db WHERE id=?''', (record_id,))
 
         self.db.conn.commit()
         self.view_records()


### PR DESCRIPTION
## Summary
- fix delete operation to pass record id as a single-element tuple
- add clarification comment for parameter binding

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899bcc36e0c832b84e2f467fcfb6108